### PR TITLE
Use square popup corners on Windows 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 </Project>

--- a/installer/wix/Bundle.wxs
+++ b/installer/wix/Bundle.wxs
@@ -2,7 +2,7 @@
      xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
   <Bundle Name="AirBridge for Windows"
           Manufacturer="AirBridge"
-          Version="1.0.1"
+          Version="1.0.2"
           UpgradeCode="7F1C28DF-D74A-4A5E-ACF8-416775882BDB">
     <BootstrapperApplication>
       <bal:WixStandardBootstrapperApplication Theme="hyperlinkLicense"

--- a/installer/wix/Package.wxs
+++ b/installer/wix/Package.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
-  <Package Name="AirBridge for Windows" Manufacturer="AirBridge" Version="1.0.1" UpgradeCode="2D36DA4C-F691-4482-9401-15B81645548E" Scope="perMachine">
+  <Package Name="AirBridge for Windows" Manufacturer="AirBridge" Version="1.0.2" UpgradeCode="2D36DA4C-F691-4482-9401-15B81645548E" Scope="perMachine">
     <MajorUpgrade DowngradeErrorMessage="A newer AirBridge version is already installed." />
     <MediaTemplate EmbedCab="yes" />
     <Icon Id="AirBridgeAppIcon" SourceFile="$(sys.CURRENTDIR)\src\AirBridge.App\Assets\AirBridge.AppIcon.ico" />

--- a/src/AirBridge.App/TrayFlyoutForm.cs
+++ b/src/AirBridge.App/TrayFlyoutForm.cs
@@ -116,7 +116,7 @@ public sealed class TrayFlyoutForm : Form
         Deactivate += (_, _) => { if (AutoHide) Hide(); };
         _receivers.Layout += (_, _) => ResizeRows();
         _receivers.ClientSizeChanged += (_, _) => ResizeRows();
-        Shown += (_, _) => WindowEffects.TryEnableRoundedCorners(this);
+        Shown += (_, _) => WindowEffects.ConfigureBorderlessPopup(this);
         SystemTextScale.Changed += OnTextScaleChanged;
         UiGeometry.ScaleInitialTextLayout(this);
         UpdateTextSizedControls();
@@ -302,13 +302,20 @@ public sealed class TrayFlyoutForm : Form
     protected override void OnPaintBackground(PaintEventArgs e)
     {
         if (_palette.IsHighContrast) { e.Graphics.Clear(SystemColors.Window); return; }
-        e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
         e.Graphics.Clear(_palette.Surface);
-        var radius = UiGeometry.Scale(this, 14);
         var bounds = Rectangle.Inflate(ClientRectangle, -1, -1);
-        using var path = UiGeometry.Rounded(bounds, radius);
         using var sidePen = new Pen(_palette.Border);
-        e.Graphics.DrawPath(sidePen, path);
+        if (WindowEffects.UseRoundedPopupCorners)
+        {
+            e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
+            using var path = UiGeometry.Rounded(bounds, UiGeometry.Scale(this, 14));
+            e.Graphics.DrawPath(sidePen, path);
+        }
+        else
+        {
+            e.Graphics.SmoothingMode = SmoothingMode.None;
+            e.Graphics.DrawRectangle(sidePen, bounds);
+        }
         var separatorY = ClientSize.Height - Padding.Bottom - UiGeometry.Scale(this, 49);
         e.Graphics.DrawLine(sidePen, Padding.Left, separatorY, ClientSize.Width - Padding.Right, separatorY);
     }
@@ -346,9 +353,11 @@ public sealed class TrayFlyoutForm : Form
 
     private void UpdateRoundedRegion()
     {
-        if (_palette.IsHighContrast || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000)) { Region = null; return; }
-        using var path = UiGeometry.Rounded(ClientRectangle, UiGeometry.Scale(this, 14));
-        Region = new Region(path);
+        // Windows 10's binary rounded regions produce visibly jagged outer
+        // edges. Keep the popup rectangular there and let DWM round Windows 11.
+        var previousRegion = Region;
+        Region = null;
+        previousRegion?.Dispose();
     }
 
     private bool IsGlobalStreamActive => _streamState is not StreamState.Idle and not StreamState.Failed;

--- a/src/AirBridge.App/UiControls.cs
+++ b/src/AirBridge.App/UiControls.cs
@@ -248,8 +248,21 @@ internal sealed class AntiAliasedLabel : Control
 internal sealed class RoundedPanel : Panel, IThemeAware
 {
     private ThemePalette _palette = ThemePalette.Current();
+    private bool _clipToRoundedRegion = true;
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     internal int Radius { get; set; } = 12;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    internal bool ClipToRoundedRegion
+    {
+        get => _clipToRoundedRegion;
+        set
+        {
+            if (_clipToRoundedRegion == value) return;
+            _clipToRoundedRegion = value;
+            UpdateRegion();
+        }
+    }
 
     public RoundedPanel()
     {
@@ -269,12 +282,19 @@ internal sealed class RoundedPanel : Panel, IThemeAware
     protected override void OnPaintBackground(PaintEventArgs e)
     {
         if (_palette.IsHighContrast) { base.OnPaintBackground(e); return; }
-        e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
         e.Graphics.Clear(Parent?.BackColor ?? _palette.Window);
         var bounds = Rectangle.Inflate(ClientRectangle, -1, -1);
-        using var path = UiGeometry.Rounded(bounds, UiGeometry.Scale(this, Radius));
         using var fill = new SolidBrush(_palette.Surface);
         using var border = new Pen(_palette.Border);
+        if (Radius <= 0)
+        {
+            e.Graphics.FillRectangle(fill, bounds);
+            e.Graphics.DrawRectangle(border, bounds);
+            return;
+        }
+
+        e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
+        using var path = UiGeometry.Rounded(bounds, UiGeometry.Scale(this, Radius));
         e.Graphics.FillPath(fill, path);
         e.Graphics.DrawPath(border, path);
     }
@@ -283,9 +303,17 @@ internal sealed class RoundedPanel : Panel, IThemeAware
 
     private void UpdateRegion()
     {
-        if (_palette.IsHighContrast) { Region = null; return; }
+        if (_palette.IsHighContrast || !ClipToRoundedRegion)
+        {
+            var previousRegion = Region;
+            Region = null;
+            previousRegion?.Dispose();
+            return;
+        }
+        var old = Region;
         using var path = UiGeometry.Rounded(ClientRectangle, UiGeometry.Scale(this, Radius));
         Region = new Region(path);
+        old?.Dispose();
     }
 }
 
@@ -580,6 +608,7 @@ internal sealed class OwnerDrawnSlider : Control, IThemeAware
 
 internal static class WindowEffects
 {
+    private const int DwmwaNcRenderingPolicy = 2;
     private const int DwmwaWindowCornerPreference = 33;
     private const int DwmwaUseImmersiveDarkModeBefore20H1 = 19;
     private const int DwmwaUseImmersiveDarkMode = 20;
@@ -587,6 +616,9 @@ internal static class WindowEffects
     private const int DwmwaCaptionColor = 35;
     private const int DwmwaTextColor = 36;
     private const int DwmwcpRound = 2;
+    private const int DwmncrpDisabled = 1;
+
+    public static bool UseRoundedPopupCorners => OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000);
 
     public static void ApplyTheme(Form form, ThemePalette palette)
     {
@@ -600,6 +632,22 @@ internal static class WindowEffects
     {
         if (!OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000)) return;
         try { var value = DwmwcpRound; _ = DwmSetWindowAttribute(form.Handle, DwmwaWindowCornerPreference, ref value, sizeof(int)); }
+        catch (DllNotFoundException) { }
+        catch (EntryPointNotFoundException) { }
+    }
+
+    public static void ConfigureBorderlessPopup(Form form)
+    {
+        if (UseRoundedPopupCorners)
+        {
+            TryEnableRoundedCorners(form);
+            return;
+        }
+
+        // Windows 10's DWM non-client shadow follows a rounded Win32 region as
+        // a bright staircase, most visibly along the lower corners. The popup
+        // paints its own border, so no non-client rendering is needed here.
+        try { var value = DwmncrpDisabled; _ = DwmSetWindowAttribute(form.Handle, DwmwaNcRenderingPolicy, ref value, sizeof(int)); }
         catch (DllNotFoundException) { }
         catch (EntryPointNotFoundException) { }
     }

--- a/src/AirBridge.App/VoiceHudForm.cs
+++ b/src/AirBridge.App/VoiceHudForm.cs
@@ -5,11 +5,11 @@ namespace AirBridge.App;
 
 internal sealed class VoiceHudForm : Form
 {
+    private const int CornerRadius = 14;
     private const int WsExNoActivate = 0x08000000;
-    private const int WsExToolWindow = 0x00000080;
     private const int CsDropShadow = 0x00020000;
     private const int WmSettingChange = 0x001A;
-    private readonly RoundedPanel _surface = new() { Dock = DockStyle.Fill, Radius = 18, Padding = new Padding(14, 10, 10, 10) };
+    private readonly RoundedPanel _surface = new() { Dock = DockStyle.Fill, Radius = WindowEffects.UseRoundedPopupCorners ? CornerRadius : 0, ClipToRoundedRegion = false, Padding = new Padding(14, 10, 10, 10) };
     private readonly VoiceMicIndicator _mic = new() { Dock = DockStyle.Fill, Margin = new Padding(0, 4, 8, 4) };
     private readonly Label _status = new() { Dock = DockStyle.Fill, AutoEllipsis = true, TextAlign = ContentAlignment.BottomLeft };
     private readonly Label _hint = new() { Dock = DockStyle.Fill, AutoEllipsis = true, TextAlign = ContentAlignment.TopLeft };
@@ -90,7 +90,11 @@ internal sealed class VoiceHudForm : Form
         WireDrag(_status);
         WireDrag(_hint);
         WireDrag(_level);
-        Shown += (_, _) => WindowEffects.TryEnableRoundedCorners(this);
+        Shown += (_, _) =>
+        {
+            WindowEffects.ApplyTheme(this, _palette);
+            WindowEffects.ConfigureBorderlessPopup(this);
+        };
         ApplyTheme(palette);
     }
 
@@ -103,8 +107,10 @@ internal sealed class VoiceHudForm : Form
         get
         {
             var parameters = base.CreateParams;
-            parameters.ExStyle |= WsExNoActivate | WsExToolWindow;
-            parameters.ClassStyle |= CsDropShadow;
+            parameters.ExStyle |= WsExNoActivate;
+            // CS_DROPSHADOW follows the binary Win32 region on Windows 10 and
+            // exposes a bright, stair-stepped fringe around rounded corners.
+            parameters.ClassStyle &= ~CsDropShadow;
             return parameters;
         }
     }
@@ -122,6 +128,11 @@ internal sealed class VoiceHudForm : Form
         _status.ForeColor = palette.Text;
         _hint.ForeColor = palette.SecondaryText;
         UpdateWindowRegion();
+        if (IsHandleCreated)
+        {
+            WindowEffects.ApplyTheme(this, palette);
+            WindowEffects.ConfigureBorderlessPopup(this);
+        }
         Invalidate(true);
     }
 
@@ -381,15 +392,11 @@ internal sealed class VoiceHudForm : Form
 
     private void UpdateWindowRegion()
     {
-        if (_palette.IsHighContrast || ClientSize.Width <= 0 || ClientSize.Height <= 0)
-        {
-            Region = null;
-            return;
-        }
-        var old = Region;
-        using var path = UiGeometry.Rounded(ClientRectangle, UiGeometry.Scale(this, 18));
-        Region = new Region(path);
-        old?.Dispose();
+        // Windows 10's binary rounded regions produce visibly jagged outer
+        // edges. Keep the HUD rectangular there and let DWM round Windows 11.
+        var previousRegion = Region;
+        Region = null;
+        previousRegion?.Dispose();
     }
 
     private void SetCompactLayout()


### PR DESCRIPTION
## Summary

- use crisp 90-degree popup corners on Windows 10
- retain native DWM-rounded popup corners on Windows 11
- disable the Windows 10 non-client rendering responsible for bright stair-stepped fringes
- bump the application, MSI, and bootstrapper version to 1.0.2

## Root cause

Windows 10 applies pixel-quantized Win32 regions and non-client shadows to the borderless rounded popups. That produces visible light stair-stepping, especially on the lower corners. The Windows 10 path now paints and clips the popups as rectangles, while Windows 11 continues to use DWM-native corner compositing.

## Validation

- `dotnet test AirBridge.sln -c Release --no-restore` — 178 passed
- `.\.venv\Scripts\python.exe -m unittest discover -s src\AirBridge.RaopHost -p "test_*.py" -v` — 20 passed
- `node --test tests\browser-extension.test.js tests\firefox-extension.test.js` — 13 passed