### PR TITLE
Credit pyatv in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ dotnet test AirBridge.sln -c Release --filter "Category=Hardware"
 
 Packaging produces `artifacts\AirBridge-Setup.exe`, `artifacts\AirBridge.msi`, and a portable application under `artifacts\publish`.
 
+## Acknowledgments
+
+AirBridge streams RAOP audio through [pyatv](https://pyatv.dev), Pierre Ståhl's excellent open-source Apple TV and AirPlay library for Python. Its clean protocol implementation is what made a file-free live `AudioSource` on Windows possible.
+
 ## License
 
 AirBridge is available under the [MIT License](LICENSE).


### PR DESCRIPTION
## What changed
- adds a concise acknowledgment of pyatv and its lead maintainer, Pierre Ståhl
- links to the official pyatv project site

## Why
AirBridge pins pyatv 0.18.0 and builds its file-free live RAOP source at pyatv's `AudioSource` seam, so the upstream project deserves explicit credit.

## Validation
- confirmed the attribution against pyatv's official project documentation
- confirmed `pyatv==0.18.0` in `src/AirBridge.RaopHost/requirements.txt`
- `git diff --check` passed