### PR TITLE
Reduce allocations in PCM normalization and receiver fanout

### DIFF
--- a/src/AirBridge.App/PcmBroadcastHub.cs
+++ b/src/AirBridge.App/PcmBroadcastHub.cs
@@ -12,6 +12,8 @@ public sealed class PcmBroadcastHub : IPcmSink
     private readonly object _gate = new();
     private readonly object _calibrationGate = new();
     private readonly Dictionary<string, BoundedPcmBuffer> _subscriptions = new(StringComparer.Ordinal);
+    // Replace only when membership changes; published arrays are never mutated.
+    private BoundedPcmBuffer[] _targets = [];
     private readonly BoundedPcmBuffer _idle = new(176400 * 5, 500);
     private readonly BoundedPcmBuffer _monitor = new(176400 * 5, 500);
     private CalibrationRun? _calibration;
@@ -34,13 +36,18 @@ public sealed class PcmBroadcastHub : IPcmSink
             if (_subscriptions.ContainsKey(receiverId)) throw new InvalidOperationException("Receiver already has a PCM subscription.");
             var buffer = new BoundedPcmBuffer(176400 * 5, targetMilliseconds);
             _subscriptions.Add(receiverId, buffer);
+            Volatile.Write(ref _targets, _subscriptions.Values.ToArray());
             return buffer;
         }
     }
 
     public void Unsubscribe(string receiverId)
     {
-        lock (_gate) _subscriptions.Remove(receiverId);
+        lock (_gate)
+        {
+            if (_subscriptions.Remove(receiverId))
+                Volatile.Write(ref _targets, _subscriptions.Values.ToArray());
+        }
     }
 
     public void Write(ReadOnlySpan<byte> source, bool producerActive = true)
@@ -114,8 +121,7 @@ public sealed class PcmBroadcastHub : IPcmSink
 
     private void WriteToTargets(ReadOnlySpan<byte> source, bool producerActive)
     {
-        BoundedPcmBuffer[] targets;
-        lock (_gate) targets = _subscriptions.Values.ToArray();
+        var targets = Volatile.Read(ref _targets);
         _monitor.Write(source, producerActive);
         foreach (var target in targets) target.Write(source, producerActive);
     }
@@ -140,16 +146,14 @@ public sealed class PcmBroadcastHub : IPcmSink
 
     public void Clear()
     {
-        BoundedPcmBuffer[] targets;
-        lock (_gate) targets = _subscriptions.Values.ToArray();
+        var targets = Volatile.Read(ref _targets);
         foreach (var target in targets) target.Clear();
         _monitor.Clear();
     }
 
     public void SetTarget(int milliseconds)
     {
-        BoundedPcmBuffer[] targets;
-        lock (_gate) targets = _subscriptions.Values.ToArray();
+        var targets = Volatile.Read(ref _targets);
         foreach (var target in targets) target.SetTarget(milliseconds);
     }
 

--- a/src/AirBridge.Core/PcmNormalizer.cs
+++ b/src/AirBridge.Core/PcmNormalizer.cs
@@ -6,7 +6,14 @@ public sealed class PcmNormalizer
     private readonly int _inputRate;
     private readonly int _channels;
     private double _sourcePosition;
-    private float[]? _previousFrame;
+    private bool _hasPreviousFrame;
+    private float _previousLeft;
+    private float _previousRight;
+    // Capture uses one normalizer serially. Retain scratch storage across packets;
+    // only the returned PCM array belongs to the caller and must remain independent.
+    private float[] _inputSamples = [];
+    private float[] _stereoSamples = [];
+    private short[] _outputSamples = [];
 
     public PcmNormalizer(int inputRate, int channels)
     {
@@ -21,7 +28,7 @@ public sealed class PcmNormalizer
     public byte[] ConvertInt16(ReadOnlySpan<byte> input)
     {
         var values = System.Runtime.InteropServices.MemoryMarshal.Cast<byte, short>(input);
-        var samples = new float[values.Length];
+        var samples = Scratch(ref _inputSamples, values.Length);
         for (var i = 0; i < values.Length; i++) samples[i] = values[i] / 32768f;
         return ConvertSamples(samples);
     }
@@ -30,23 +37,26 @@ public sealed class PcmNormalizer
     {
         var frames = samples.Length / _channels;
         if (frames == 0) return [];
-        var withPrevious = new float[(frames + (_previousFrame is null ? 0 : 1)) * 2];
+        var withPrevious = Scratch(ref _stereoSamples, (frames + (_hasPreviousFrame ? 1 : 0)) * 2);
         var offset = 0;
-        if (_previousFrame is not null)
+        if (_hasPreviousFrame)
         {
-            withPrevious[0] = _previousFrame[0];
-            withPrevious[1] = _previousFrame[1];
+            withPrevious[0] = _previousLeft;
+            withPrevious[1] = _previousRight;
             offset = 1;
         }
         for (var frame = 0; frame < frames; frame++)
         {
             (withPrevious[(frame + offset) * 2], withPrevious[(frame + offset) * 2 + 1]) = Downmix(samples, frame);
         }
-        _previousFrame = [withPrevious[^2], withPrevious[^1]];
+        _previousLeft = withPrevious[^2];
+        _previousRight = withPrevious[^1];
+        _hasPreviousFrame = true;
 
         var totalFrames = frames + offset;
         var step = _inputRate / 44100d;
-        var output = new List<short>((int)(frames / step + 2) * 2);
+        var output = Scratch(ref _outputSamples, (int)(frames / step + 2) * 2);
+        var outputCount = 0;
         while (_sourcePosition + 1 < totalFrames)
         {
             var index = (int)_sourcePosition;
@@ -55,14 +65,20 @@ public sealed class PcmNormalizer
             {
                 var a = withPrevious[index * 2 + channel];
                 var b = withPrevious[(index + 1) * 2 + channel];
-                output.Add(ToInt16(a + ((b - a) * fraction)));
+                output[outputCount++] = ToInt16(a + ((b - a) * fraction));
             }
             _sourcePosition += step;
         }
         _sourcePosition -= totalFrames - 1;
-        var bytes = new byte[output.Count * sizeof(short)];
-        output.CopyTo(System.Runtime.InteropServices.MemoryMarshal.Cast<byte, short>(bytes));
+        var bytes = new byte[outputCount * sizeof(short)];
+        output[..outputCount].CopyTo(System.Runtime.InteropServices.MemoryMarshal.Cast<byte, short>(bytes));
         return bytes;
+    }
+
+    private static Span<T> Scratch<T>(ref T[] buffer, int length)
+    {
+        if (buffer.Length < length) buffer = new T[length];
+        return buffer.AsSpan(0, length);
     }
 
     private (float Left, float Right) Downmix(ReadOnlySpan<float> samples, int frame)
@@ -81,4 +97,3 @@ public sealed class PcmNormalizer
 
     private static short ToInt16(float value) => (short)Math.Round(Math.Clamp(value, -1f, 1f) * (value < 0 ? 32768f : 32767f));
 }
-

--- a/tests/AirBridge.Tests/MultiReceiverTests.cs
+++ b/tests/AirBridge.Tests/MultiReceiverTests.cs
@@ -72,6 +72,51 @@ public sealed class MultiReceiverTests
     }
 
     [Fact]
+    public void FanoutUpdatesMembershipAndControlsAfterUnsubscribeAndResubscribe()
+    {
+        var hub = new PcmBroadcastHub();
+        var removed = hub.Subscribe(SpeakerA.Id);
+        var healthy = hub.Subscribe(Office.Id);
+        hub.Write(new byte[] { 1, 2, 3, 4 });
+        hub.Unsubscribe(SpeakerA.Id);
+        hub.Unsubscribe("unknown");
+        var replacement = hub.Subscribe(SpeakerA.Id);
+        hub.Write(new byte[] { 5, 6, 7, 8 });
+
+        var read = new byte[4];
+        Assert.Equal(4, removed.Read(read, false));
+        Assert.Equal(new byte[] { 1, 2, 3, 4 }, read);
+        Assert.Equal(0, removed.Read(read, false));
+        Assert.Equal(4, replacement.Read(read, false));
+        Assert.Equal(new byte[] { 5, 6, 7, 8 }, read);
+        Assert.Equal(8, healthy.Snapshot().FillBytes);
+
+        hub.SetTarget(700);
+        hub.Clear();
+        Assert.Equal(500, removed.TargetMilliseconds);
+        Assert.Equal(700, replacement.TargetMilliseconds);
+        Assert.Equal(700, healthy.TargetMilliseconds);
+        Assert.Equal(0, healthy.Snapshot().FillBytes);
+        Assert.Equal(0, hub.MonitorBuffer.Snapshot().FillBytes);
+    }
+
+    [Fact]
+    public void SteadyStateFanoutDoesNotAllocate()
+    {
+        var hub = new PcmBroadcastHub();
+        hub.Subscribe(SpeakerA.Id);
+        hub.Subscribe(Office.Id);
+        var block = new byte[SharedAudioPump.BlockBytes];
+        for (var i = 0; i < 100; i++) hub.Write(block);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 100; i++) hub.Write(block);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(0, allocated);
+    }
+
+    [Fact]
     public async Task CalibrationIsMixedIntoSharedCaptureFanoutForEveryLeg()
     {
         var hub = new PcmBroadcastHub();

--- a/tests/AirBridge.Tests/PcmNormalizerTests.cs
+++ b/tests/AirBridge.Tests/PcmNormalizerTests.cs
@@ -40,6 +40,62 @@ public sealed class PcmNormalizerTests
     }
 
     [Fact]
+    public void UpsamplingInterpolatesAcrossEmptyAndSmallerPacketsWithoutChangingPriorOutput()
+    {
+        var normalizer = new PcmNormalizer(22050, 1);
+        float[] first = [0f, 1f, 0f];
+        var output = normalizer.ConvertFloat32(MemoryMarshal.AsBytes(first.AsSpan()));
+        short[] expected = [0, 0, 16384, 16384, 32767, 32767, 16384, 16384];
+        Assert.Equal(expected, MemoryMarshal.Cast<byte, short>(output).ToArray());
+
+        Assert.Empty(normalizer.ConvertFloat32([]));
+        float[] second = [-.5f];
+        var next = normalizer.ConvertFloat32(MemoryMarshal.AsBytes(second.AsSpan()));
+        Assert.Equal(new short[] { 0, 0, -8192, -8192 }, MemoryMarshal.Cast<byte, short>(next).ToArray());
+        Assert.Equal(expected, MemoryMarshal.Cast<byte, short>(output).ToArray());
+    }
+
+    [Theory]
+    [InlineData(22050, 1)]
+    [InlineData(44100, 2)]
+    [InlineData(48000, 6)]
+    [InlineData(96000, 8)]
+    public void Int16AndFloatAgreeAcrossChangingPacketSizes(int rate, int channels)
+    {
+        var integers = new PcmNormalizer(rate, channels);
+        var floats = new PcmNormalizer(rate, channels);
+        var random = new Random(6127);
+        foreach (var frames in new[] { 1, 960, 0, 13, 2048, 1, 480, 0, 127 })
+        {
+            var input = new short[frames * channels];
+            for (var i = 0; i < input.Length; i++) input[i] = (short)random.Next(-32768, 32768);
+            var floatInput = input.Select(value => value / 32768f).ToArray();
+            Assert.Equal(
+                floats.ConvertFloat32(MemoryMarshal.AsBytes(floatInput.AsSpan())),
+                integers.ConvertInt16(MemoryMarshal.AsBytes(input.AsSpan())));
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SteadyStateConversionAllocatesOnlyTheReturnedPcm(bool int16)
+    {
+        var normalizer = new PcmNormalizer(48000, 2);
+        var input = new byte[960 * 2 * (int16 ? sizeof(short) : sizeof(float))];
+        for (var i = 0; i < 100; i++) Convert();
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        long outputBytes = 0;
+        for (var i = 0; i < 100; i++) outputBytes += Convert().Length;
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        // Allow an array header and alignment per returned packet, but no scratch arrays.
+        Assert.InRange(allocated, outputBytes, outputBytes + 100 * 32);
+        byte[] Convert() => int16 ? normalizer.ConvertInt16(input) : normalizer.ConvertFloat32(input);
+    }
+
+    [Fact]
     public async Task WindowsLoopbackAcceptsItsNativeExtensibleFormatWhenAudioArrives()
     {
         if (!HardwareTestGate.Enabled) return;


### PR DESCRIPTION
Live capture created temporary conversion arrays for every audio packet and copied the receiver list on every fanout write. Reuse normalization scratch buffers and publish an immutable receiver snapshot only when subscriptions change, reducing garbage collection pressure during continuous playback. Each returned PCM packet remains independently owned by its caller.

Add regressions for interpolation across packet boundaries, empty and varying packet sizes, returned-output ownership, subscription changes, and steady-state allocation budgets.

### Measurements

Local Release .NET 9 microbenchmark using 20 ms, 48 kHz stereo capture packets; 5,000 warmup calls and median of five 20,000-call trials, with tiered compilation disabled:

| Workload | Allocated bytes per call, before → after | Time per call, before → after |
| --- | --- | --- |
| Float32 normalization | 14,888 → 3,552 (76% reduction) | 18.752 → 17.745 µs |
| Int16 normalization | 22,592 → 3,552 (84% reduction) | 19.652 → 19.084 µs |
| Fanout to four receivers | 56 → 0 | 0.465 → 0.430 µs |

These are synthetic hot-path measurements; no end-to-end playback latency improvement is claimed. The normalizer retains scratch buffers sized to the largest packet seen during its lifetime.

### Validation

- Before/after PCM comparison: byte-identical across 5,600 packets at seven sample rates (8–192 kHz), with mono, stereo, six-channel, and eight-channel input.
- 51 focused audio tests passed.
- Full solution test run on the PR branch: 185 unit tests passed, one existing quarantined pipe test was skipped, and the Windows Credential Manager round-trip test failed. The credential test also failed before these changes because it could not write credentials in this environment. The eval project reported two passing tests; its paid model evaluation was disabled.
- Hardware playback tests were not enabled.
- `git diff --check` passed.
